### PR TITLE
Fix: Correct asset paths for GitHub Pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "prebuild": "rimraf dist",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && gh-pages -d dist",
     "deploy:netlify": "npm run build",
     "serve": "npm run build && npm run preview"
   },

--- a/src/utils/Loader.js
+++ b/src/utils/Loader.js
@@ -12,7 +12,7 @@ export function preloadAssets() {
 function loadModels() {
   const loader = new GLTFLoader();
   const toLoad = [
-    { name: 'dino', path: '/assets/models/characters/dino.glb' },
+    { name: 'dino', path: import.meta.env.BASE_URL + 'assets/models/characters/dino.glb' },
     // Add any other models here
   ];
 
@@ -39,11 +39,11 @@ function loadSounds() {
   const toLoad = [
     {
       name: 'jump',
-      src: ['/assets/audio/jump.mp3']
+      src: [import.meta.env.BASE_URL + 'assets/sounds/jump.mp3']
     },
     {
       name: 'collision',
-      src: ['/assets/audio/collision.mp3']
+      src: [import.meta.env.BASE_URL + 'assets/sounds/collision.mp3']
     }
     // Add other sounds here
   ];


### PR DESCRIPTION
The game was showing a blank page on GitHub Pages due to incorrect asset loading paths. Models and sounds were being referenced with absolute paths (e.g., /assets/model.glb) instead of paths relative to the repository's base URL on GitHub Pages.

This commit fixes the issue by:
- Modifying `src/utils/Loader.js` to prepend `import.meta.env.BASE_URL` to all model and sound asset paths. This Vite-provided variable ensures paths are correct for both local development and production builds on GitHub Pages.
- Correcting a typo in sound asset paths from `/assets/audio/` to `/assets/sounds/` to match the actual directory structure.

Additionally, this commit removes a redundant `deploy` script from `package.json` that used the `gh-pages` package. The project already has a GitHub Action for deploying to GitHub Pages, making this script unnecessary and potentially confusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the deploy script for publishing to GitHub Pages.

- **Refactor**
  - Updated asset loading paths to dynamically use the app’s base URL, improving compatibility with different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->